### PR TITLE
修复gitment默认id导致初始化失败的bug

### DIFF
--- a/_comment.html
+++ b/_comment.html
@@ -32,7 +32,7 @@
             $.getScript('https://imsun.github.io/gitment/dist/gitment.browser.js', function() {
                 var gitment_config = '{{.Site.Comment}}'.split(':');
                 var gitment = new Gitment({
-                    id: {{.Date}},
+                    id: String({{.Date}}),
                     owner: gitment_config[0],
                     repo: gitment_config[1],
                     oauth: {

--- a/_comment.html
+++ b/_comment.html
@@ -32,6 +32,7 @@
             $.getScript('https://imsun.github.io/gitment/dist/gitment.browser.js', function() {
                 var gitment_config = '{{.Site.Comment}}'.split(':');
                 var gitment = new Gitment({
+                    id: {{.Date}},
                     owner: gitment_config[0],
                     repo: gitment_config[1],
                     oauth: {


### PR DESCRIPTION
当gitment默认id长度超过github限制的50字符时，将不能正确初始化
修改为使用长度固定的页面date可以解决

Signed-off-by: Nigh <jiyucheng007@gmail.com>